### PR TITLE
docker: Share sota dir with dockerd container

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     volumes:
       - ${DOCKER_DATA_ROOT}:/var/lib/docker
       - docker-runtime:/var/run/docker
+      - ${SOTA_DIR}:/var/sota
     privileged: true
 
   sotactl:


### PR DESCRIPTION
Share the sota dir with dockerd container so a user can bind mount local directory or file located within the compose app dir which is `/var/sota/compose-apps/<app>`. For example:

cat docker-compose.yml
```
...
volumes:
   - ./nginx.conf:/etc/nginx/nginx.conf:ro
...

```