### PR TITLE
docker: Use Foundries dockerd instead of vanilla one

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   dockerd:
-    image: docker:25.0-dind 
+    image: ghcr.io/foundriesio/moby:25.0.3_fio
     command: ["dockerd", "-H", "unix:///var/run/docker/docker.sock"] 
     volumes:
       - ${DOCKER_DATA_ROOT}:/var/lib/docker


### PR DESCRIPTION
Use the foundries version of docked which contains the patches that are added to the docked version running on LmP.