### PR TITLE
docker: Remove ubuntu user in entrypoint script

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -5,6 +5,9 @@ if [ -z $DEV_USER ] || [ -z $DEV_GROUP ]; then
     exit 1
 fi
 
+# Recent ubuntu images have a user named 'ubuntu' with UID 1000, which might conflict with $DEV_USER.
+deluser ubuntu 2> /dev/null || true
+
 # Create a group with the specified GID if it doesn't already exist
 if ! getent group $DEV_GROUP >/dev/null; then
     groupadd -g $DEV_GROUP devgrp


### PR DESCRIPTION
This is required since the latest ubuntu container images have a `ubuntu` user with PID 1000, which conflicts may conflict with ${DEV_USER}.

---
@mike-sul this change was meant to be included in the last commit (updating containers).